### PR TITLE
feat: add task executor

### DIFF
--- a/contracts/safe.clar
+++ b/contracts/safe.clar
@@ -100,6 +100,7 @@
     threshold: uint,
     approvals: uint,
     executed: bool,
+    executor: principal,
   }
 )
 
@@ -130,6 +131,7 @@
       threshold: (var-get cfgThreshold),
       approvals: u0,
       executed: false,
+      executor: contract-caller,
     })
 
     (var-set lastTaskId newTaskId)
@@ -157,6 +159,7 @@
     ((task (unwrap! (get-task id) ERR_UNKNOWN_TASK)))
     (asserts! (is-owner tx-sender) ERR_NOT_AUTHORIZED)
     (asserts! (>= (get approvals task) (get threshold task)) ERR_NOT_APPROVED)
+    (asserts! (is-eq contract-caller (get executor task)) ERR_NOT_AUTHORIZED)
     (asserts! (not (get executed task)) ERR_ALREADY_EXECUTED)
 
     (map-set Tasks id (merge task {executed: true}))

--- a/models/safe.model.ts
+++ b/models/safe.model.ts
@@ -107,4 +107,5 @@ export interface Task {
   threshold: string;
   approvals: string;
   executed: string;
+  executor: string;
 }


### PR DESCRIPTION
This PR introduces task executor "role".
It is used to determine who can and who cannot mark task as executed. 

close #13 